### PR TITLE
Python Sorter

### DIFF
--- a/sorter.py
+++ b/sorter.py
@@ -1,0 +1,76 @@
+import json, sys
+from tkinter import Tk, filedialog
+from tkinter.filedialog import askopenfilename
+from difflib import SequenceMatcher
+from IPython import get_ipython
+get_ipython().magic('reset -sf') 
+
+# From https://stackoverflow.com/questions/19476232/save-file-dialog-in-tkinter, I'm lazy
+def file_save(text):
+    f = filedialog.asksaveasfile(mode='w', defaultextension=".json", filetypes=[('JSON Files','*.json')], title="Save the sorted JSON", initialfile='sorted')
+    if f is None: # asksaveasfile return `None` if dialog closed with "cancel".
+        return
+    text2save = text.replace("\'","\"") # starts from `1.0`, not `0.0`
+    f.seek(0)
+    f.truncate()
+    f.write(text2save)
+    f.close() # `()` was missing.   
+
+root = Tk()
+root.call('wm', 'attributes', '.', '-topmost', True)
+root.withdraw()
+filename = askopenfilename(title = "Select existing JSON for sorting", filetypes=[('JSON Files','*.json')]);
+if not filename:
+    sys.exit("No file selected")
+    
+desired = input("Paste the desired load order, with each mod title on a seperate line:\n")
+typocon = float(input("Define typo confidence (0.00-1.00, default = 0.50): ") or 0.50)
+if (typocon < 0 or typocon > 1):
+    sys.exit("Invalid input for typo confidence.")
+elif (typocon < 0.5 or typocon > 0.7):
+    print('\nToo low or high typo confidence can result in mods not being found and therefore properly sorted\n')
+#sortfilt = input("Mod ID (1)\nSteam ID (2)\nName (3)\nChoose sorting filter: ")
+#if (sortfilt <= 0 or sortfilt > 3):
+#    sys.exit("Sort filter selection out of bounds [1-3]")
+
+splitDesires = desired.split("\n")
+done = []
+with open(filename) as f:
+    og = json.loads(f.read())
+    for i, tosort in enumerate(splitDesires):
+        highestConfidence = float(0)
+        highConMod = None
+        for mod in og["Mods"]:
+            #print('=== Looking for mod ===', end="")
+            thisRatio = SequenceMatcher(None, a=splitDesires[i],b=mod["DisplayName"]).ratio()
+            #print('Comparing mod ' + str(mod["DisplayName"]) + ' to ' + str(splitDesires[i]) + ': ' + str(thisRatio) + '\n')
+            if (thisRatio > highestConfidence):
+                highestConfidence = thisRatio
+                if (thisRatio > typocon):
+                    highConMod = mod
+        if highConMod is not None:
+            #print('\n     Mod ' + str(highConMod["steamId"]) + ' (\"' + str(highConMod["DisplayName"]) + '\") was selected for \"' + str(splitDesires[i]) + '\" with a confidence of ' + str(highestConfidence) + '\n' + str(highConMod))
+            highConMod["DisplayName"] = highConMod["DisplayName"].replace('\'','')
+            done.append(highConMod)
+        else:
+            print('\nNo sequence within confidence bounds matches mod \"' + str(splitDesires[i]) + '\", for which the highest confidence was ' + str(round(highestConfidence,3)) + '. Perhaps the mod\'s name has unrecognized special characters. Lowering the confidence threshold should help with this, but use caution.\n')
+   
+    #Switch playlist positions with previous configuration
+    done = list({ each['steamId'] : each for each in done }.values())
+    for i, mod in enumerate(done):
+        ppp = og["Mods"][i]["PlaysetPosition"]
+        print("Mod #" + str(i) + "\'s playset position has changed from " + mod["PlaysetPosition"] + ' to ' + str(ppp))
+        mod["PlaysetPosition"] = ppp
+        
+        
+    #print('Finished sorting. Here is the new JSON:\n\n' + str(done).replace("},","}\n"))
+    og["Mods"] = done
+    #print('Orgs mods is now:\n' + str(og["Mods"]).replace('},','}\n') + '\n\n')
+    #print('Resulting in \n\n' + str(og))
+    file_save(json.dumps(og, separators=(',', ':')))
+#print(done)
+
+for mod in og["Mods"]:
+    print(mod["DisplayName"])
+
+             


### PR DESCRIPTION
A lot of the available, and quite fun, collections on Steam feature a 'suggested' load order for their mods. Often times, however, the author suggesting this load order does not include a playset file. Instead, they just list their mod order recommendations:

> mod 1: Immersive Space...
> mod 5: Planet Modifiers... etc

The attached python script will allow you to sort your existing playsets based on the mod author's recommendations, without a playset file. In order to do so, you can follow these steps:

1. Using Stellaris-Playset-Sync, export your existing playset JSONs that you want to sort. (If you do not yet have a playset, make one on the Stellaris launcher and then add all of the unsorted mods you'll want to sort)
2. Run the python script and supply the following: a list of mods seperated on individual lines _(you can often just copy and paste the author's recommendations),_ and a tolerance percentage for mispelling and typos. 
3. Save the sorted JSON file somewhere memorable
4. Using Stellaris-Playset-Sync, import this new sorted file
5. Using the Stellaris launcher, enable your mods, select your playset, and begin ~~subjugating your enemies, enslaving their families and endlessly hiring marauders to attack them~~ creating a peaceful commonwealth for the galaxy!

In the near future I plan on integrating this python script into the C# Stellaris-Playset-Sync so that the features are native :).